### PR TITLE
Add autodetection for vhd files.

### DIFF
--- a/fns.h
+++ b/fns.h
@@ -23,6 +23,9 @@ int	atacmd(Ataregs *, uchar *, int, int);
 void *	create_bpf_program(int, int);
 void	free_bpf_program(void *);
 
+// vhd.c
+int	autodetect_vhdfile(int fd, vlong *size);
+
 // os specific
 
 int	dial(char *, int);

--- a/makefile
+++ b/makefile
@@ -8,7 +8,7 @@ sbindir = ${prefix}/sbin
 sharedir = ${prefix}/share
 mandir = ${sharedir}/man
 
-O=aoe.o bpf.o ${PLATFORM}.o ata.o
+O=aoe.o bpf.o ${PLATFORM}.o ata.o vhd.o
 CFLAGS += -Wall -g -O2
 CC = gcc
 
@@ -25,6 +25,9 @@ ata.o : ata.c config.h dat.h fns.h makefile
 	${CC} ${CFLAGS} -c $<
 
 bpf.o : bpf.c
+	${CC} ${CFLAGS} -c $<
+
+vhd.o : vhd.c config.h dat.h fns.h makefile
 	${CC} ${CFLAGS} -c $<
 
 config.h : config/config.h.in makefile

--- a/vblade.8
+++ b/vblade.8
@@ -34,6 +34,11 @@ communications.
 The name of the regular file or block device to export.
 .SS Options
 .TP
+\fB-a\fP
+The -a flag auto detects VHD files. Only the fixed disk format is
+supported. If found then the size of the VHD disk is used. Dynamic
+disks and corrupted VHD files are rejected.
+.TP
 \fB-b\fP
 The -b flag takes an argument, the advertised buffer count, specifying
 the maximum number of outstanding messages the server can queue for

--- a/vhd.c
+++ b/vhd.c
@@ -1,0 +1,87 @@
+// vhd.c: Check for a Virtual Hard Disk file
+#define _GNU_SOURCE
+#include "config.h"
+#include <endian.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include "dat.h"
+#include "fns.h"
+
+struct _DiskGeometry
+{
+	uint16_t cylinder;
+	uint8_t heads;
+	uint8_t sectors;
+} __attribute__ ((packed));
+typedef struct _DiskGeometry DiskGeometry;
+
+struct _HardDiskFooter
+{
+    char cookie[8];
+    uint32_t features;
+    uint32_t fileFormatVersion;
+    uint64_t dataOffset;
+    uint32_t timeStamp;
+    uint32_t creatorApplication;
+    uint32_t creatorVersion;
+    uint32_t creatorHostOS;
+    uint64_t originalSize;
+    uint64_t currentSize;
+    DiskGeometry diskGeometry;
+    uint32_t diskType;
+    uint32_t checksum;
+    uint64_t uniqueId[2];
+    uint8_t savedState;
+    uint8_t reserved[427];
+} __attribute__ ((packed));
+typedef struct _HardDiskFooter HardDiskFooter;
+
+static uint32_t calc_checksum(void *data, size_t size)
+{
+	size_t i;
+	uint32_t chksum;
+
+	for (chksum = 0, i = 0; i < size; i++)
+		chksum += ((uint8_t*)data)[i];
+	return ~chksum;
+}
+
+int
+autodetect_vhdfile(int fd, vlong *size)
+{
+	HardDiskFooter hdf;
+	struct stat st;
+	int32_t chksum;
+
+	if (-1 == fstat(fd, &st)) {
+		perror("fstat");
+		exit(1);
+	}
+	if (!S_ISREG(st.st_mode)) return 0; // Not a regular file
+	if (-1 == lseek64(fd, -sizeof(hdf), SEEK_END)) {
+		perror("lseek64");
+		exit(1);
+	}
+	if (sizeof(hdf) != read(fd, &hdf, sizeof(hdf))) {
+		perror("read");
+		exit(1);
+	}
+	if (-1 == lseek64(fd, 0, SEEK_SET)) {
+		perror("lseek64");
+		exit(1);
+	}
+	if (strncmp((const char*) &hdf.cookie, "conectix", 8)) return 0; // Cookie not found
+	if (be32toh(hdf.fileFormatVersion) != 0x00010000) return -1; // Wrong file format
+	if (be32toh(hdf.diskType) != 2) return -2; // Not a fixed disk
+	chksum = be32toh(hdf.checksum);
+	hdf.checksum = 0;
+	if (chksum != calc_checksum(&hdf, sizeof(hdf))) return -3; // Wrong checksum
+	if (be64toh(hdf.currentSize) > st.st_size-sizeof(hdf)) return -4; // Wrong size
+	*size = (vlong) be64toh(hdf.currentSize);
+	return 1;
+}


### PR DESCRIPTION
vhd files are often used as storage containers. This PR adds a new
commandline switch to check for vhd files. This has the following
advantages:
- Dynamic vhd files are rejected so you can't destroy them.
- Size of the image is adjusted to exclude the management block.
