### PR TITLE
Deal with a missing interface

### DIFF
--- a/aoe.c
+++ b/aoe.c
@@ -536,6 +536,8 @@ main(int argc, char **argv)
 	}
 	ifname = argv[2];
 	sfd = dial(ifname, bufcnt);
+	if (sfd < 0)
+		return 1;
 	getea(sfd, ifname, mac);
 	printf("pid %ld: e%d.%d, %lld sectors %s\n",
 		(long) getpid(), shelf, slot, size,

--- a/linux.c
+++ b/linux.c
@@ -47,6 +47,10 @@ dial(char *eth, int bufcnt)		// get us a raw connection to an interface
 		return -1;
 	}
 	i = getindx(s, eth);
+	if (i < 0) {
+		perror(eth);
+		return -1;
+	}
 	sa.sll_family = AF_PACKET;
 	sa.sll_protocol = htons(0x88a2);
 	sa.sll_ifindex = i;


### PR DESCRIPTION
At the moment, vblade handles an unknown or missing interface
to bind to not that well (seen on Linux):

| bind funky: No such device
| Can't get hw addr: Bad file descriptor
| pid 1664: e12.3, 131072 sectors O_RDWR
| Can't get mtu: Bad file descriptor
| putpkt aoe id: Bad file descriptor
| read network: Bad file descriptor

Two problems here:

* (linux only) In dial, the getindx result is not checked. The following
  bind call however fails for an invalid interface index. But "bind funky"
  isn't quite a helpful error message.

* The main routine does not check the dial result.

Patches for both are fairly simple. The freebsd counterpart for the
first one is missing, though.