### PR TITLE
typo

### DIFF
--- a/aoe.c
+++ b/aoe.c
@@ -83,7 +83,7 @@ getlba(uchar *p)
 }
 
 int
-aoeata(Ata *p, int pktlen)	// do ATA reqeust
+aoeata(Ata *p, int pktlen)	// do ATA request
 {
 	Ataregs r;
 	int len = 60;


### PR DESCRIPTION
@ecashin

I'm ignoring the contrib/*.diff file, the contrib/README file is circa version 12.

```
$ grep -n reqeust /tmp/vblade/aoe.c
86:aoeata(Ata *p, int pktlen)   // do ATA reqeust
$ 
```

The manpage's line 87 might be reworded.

```
$ sed -n '85,88p' /tmp/vblade/vblade.8
At least one AoE initiator (WinAoE) has been found to enforce legacy
CHS geometry for drives by discarding sectors. You should ensure that
the underlaying regular file or block device size is a multiple of
8225280 bytes (255 heads, 63 sectors/track, 512 bytes/sector) if you
$ 
```